### PR TITLE
Fix configuration of calcium

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -88,7 +88,7 @@ examples: library $(EXMP_SOURCES)
 $(CALCIUM_LIB): $(LOBJS) $(LIB_SOURCES) $(EXT_SOURCES) $(HEADERS) $(EXT_HEADERS) | build build/interfaces
 	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir); BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) shared || exit $$?;))
 	$(AT)$(foreach dir, $(BUILD_DIRS), mkdir -p build/$(dir); BUILD_DIR=../build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) shared || exit $$?;)
-	$(CC) $(ABI_FLAG) -shared $(EXTRA_SHARED_FLAGS) $(LOBJS) $(MOD_LOBJS) $(EXT_OBJS) -o $(CALCIUM_LIB) $(LDFLAGS) $(LIBS2); \
+	$(CC) $(ABI_FLAG) -shared $(EXTRA_SHARED_FLAGS) $(LOBJS) $(MOD_LOBJS) $(EXT_OBJS) -o $(CALCIUM_LIB) $(LDFLAGS) $(LIBS2); 
 	-$(AT)if [ "$(CALCIUM_SOLIB)" -eq "1" ]; then \
 		$(LDCONFIG) -n "$(CURDIR)"; \
 	fi

--- a/ca.h
+++ b/ca.h
@@ -20,8 +20,8 @@
 
 #include <stdio.h>
 #include "flint/flint.h"
-#include "nf.h"
-#include "nf_elem.h"
+#include "antic/nf.h"
+#include "antic/nf_elem.h"
 #include "calcium.h"
 #include "qqbar.h"
 #include "fmpz_mpoly_q.h"

--- a/configure
+++ b/configure
@@ -232,7 +232,7 @@ else
 fi
 
 if [ -d "${FLINT_INC_DIR}/flint" ]; then
-   FLINT_INC_DIR="${FLINT_INC_DIR}/flint"
+   FLINT_INC_DIR="${FLINT_INC_DIR}"
 elif [ -f "${FLINT_INC_DIR}/flint.h" ]; then
    mkdir -p build/include
    ln -sf ${FLINT_INC_DIR} build/include/flint
@@ -291,8 +291,8 @@ else
 fi
 
 if [ -d "${ANTIC_INC_DIR}/antic" ]; then
-   ANTIC_INC_DIR="${ANTIC_INC_DIR}/antic"
-elif [ -f "${ANTIC_INC_DIR}/antic.h" ]; then
+   ANTIC_INC_DIR="${ANTIC_INC_DIR}"
+elif [ -f "${ANTIC_INC_DIR}/nf.h" ]; then
    mkdir -p build/include
    ln -sf ${ANTIC_INC_DIR} build/include/antic
    ANTIC_INC_DIR="${PWD}/build/include"

--- a/configure
+++ b/configure
@@ -232,7 +232,7 @@ else
 fi
 
 if [ -d "${FLINT_INC_DIR}/flint" ]; then
-   FLINT_INC_DIR="${FLINT_INC_DIR}"
+   FLINT_INC_DIR="${FLINT_INC_DIR}/flint"
 elif [ -f "${FLINT_INC_DIR}/flint.h" ]; then
    mkdir -p build/include
    ln -sf ${FLINT_INC_DIR} build/include/flint
@@ -288,6 +288,14 @@ elif [ -d "${ANTIC_DIR}" ]; then
 else
    echo "Invalid ANTIC directory"
    exit 1
+fi
+
+if [ -d "${ANTIC_INC_DIR}/antic" ]; then
+   ANTIC_INC_DIR="${ANTIC_INC_DIR}/antic"
+elif [ -f "${ANTIC_INC_DIR}/antic.h" ]; then
+   mkdir -p build/include
+   ln -sf ${ANTIC_INC_DIR} build/include/antic
+   ANTIC_INC_DIR="${PWD}/build/include"
 fi
 
 echo "ANTIC_LIB_DIR set to ${ANTIC_LIB_DIR}"


### PR DESCRIPTION
These are what I need to get calcium to build cleanly on osx.  There are essentially two changes.
First the antic includes are expected to be addressed like "antic/nf.h" etc.  Second, a spurious backslash was removed.