### PR TITLE
Changed pyca.fexpr.__call__

### DIFF
--- a/pycalcium/pyca.py
+++ b/pycalcium/pyca.py
@@ -349,12 +349,10 @@ class fexpr:
         elif n == 4:
             libcalcium.fexpr_call4(res, self, args2[0], args2[1], args2[2], args2[3])
         else:
-            vec = libcalcium.flint_malloc(n * ctypes.sizeof(fexpr_struct))
-            vec = ctypes.cast(vec, ctypes.POINTER(fexpr_struct))
+            vec = (fexpr_struct * n)()
             for i in range(n):
-                vec[i] = ctypes.cast(args2[i], ctypes.POINTER(fexpr_struct))[0]
+                vec[i] = args2[i]._data
             libcalcium.fexpr_call_vec(res, self, vec, n)
-            libcalcium.flint_free(vec)
         return res
 
     def contains(self, x):


### PR DESCRIPTION
Pyca crashes on OSX when you attempt to call an fexpr with more than 4 parameters (this happens often in test_latex.py).  I changed it so that the array of parameters is allocated on the python side.  I don't think this should cause any problems, there does not seem to be any realloccing of the args in fexpr_call_vec().


The old dance with the array allocated in C crashed.
Changed to use Python allocated array.